### PR TITLE
Export resource strings as self-described types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 script:
 - npm run lint
 - npm run build
+# validate dist doesn't contain package imports:
+- npm run lint-dist
 
 before_deploy:
 # copy files

--- a/package-lock.json
+++ b/package-lock.json
@@ -745,12 +745,6 @@
         }
       }
     },
-    "core-js-pure": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1306,13 +1300,12 @@
       "dev": true
     },
     "igniteui-angular": {
-      "version": "10.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/igniteui-angular/-/igniteui-angular-10.1.0-beta.0.tgz",
-      "integrity": "sha512-EGsKEK6UzsTf3+D9XZ5m5Hiy37RjwrOYYpip0w6Ghg2ukwCfIanT+gxsZv/dGvVzIxdSLfOWazXCIcFHqKEN7g==",
+      "version": "10.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/igniteui-angular/-/igniteui-angular-10.1.0-rc.0.tgz",
+      "integrity": "sha512-X3KGyDpXCA5qBkmlwHp/jTplau2/1TXofPHriIy3cvPoKRw8L5EMBZlvZlM2uyJ2LF9Czqv36LWEHGlIrD2QLg==",
       "dev": true,
       "requires": {
         "@types/hammerjs": "^2.0.36",
-        "core-js-pure": "^3.6.5",
         "hammerjs": "^2.0.8",
         "igniteui-trial-watermark": "^1.0.3",
         "jszip": "^3.5.0",
@@ -1322,9 +1315,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,15 +307,6 @@
       "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==",
       "dev": true
     },
-    "@types/jszip": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.1.tgz",
-      "integrity": "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==",
-      "dev": true,
-      "requires": {
-        "jszip": "*"
-      }
-    },
     "@types/node": {
       "version": "10.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
@@ -753,6 +744,12 @@
           }
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1309,16 +1306,17 @@
       "dev": true
     },
     "igniteui-angular": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/igniteui-angular/-/igniteui-angular-10.0.0.tgz",
-      "integrity": "sha512-rqP1H0hipFzJQ4AqVA0NDfHpsD3l6ku8qPP9eOvgziTSZkZo0XtRj9cYdLVsPmp90FGKbNPjihU1koeLTaS5mA==",
+      "version": "10.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/igniteui-angular/-/igniteui-angular-10.1.0-beta.0.tgz",
+      "integrity": "sha512-EGsKEK6UzsTf3+D9XZ5m5Hiy37RjwrOYYpip0w6Ghg2ukwCfIanT+gxsZv/dGvVzIxdSLfOWazXCIcFHqKEN7g==",
       "dev": true,
       "requires": {
         "@types/hammerjs": "^2.0.36",
-        "@types/jszip": "^3.1.7",
+        "core-js-pure": "^3.6.5",
         "hammerjs": "^2.0.8",
         "igniteui-trial-watermark": "^1.0.3",
-        "jszip": "^3.3.0",
+        "jszip": "^3.5.0",
+        "lodash.merge": "^4.6.2",
         "resize-observer-polyfill": "^1.5.1",
         "tslib": "^2.0.0"
       },
@@ -1683,6 +1681,12 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "tslint 'src/**/*.ts'"
+    "lint": "tslint 'src/**/*.ts'",
+    "lint-dist": "tslint 'dist/**/*.d.ts' -c tslint.dist.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/forms": "^10.0.0",
     "@angular/platform-browser": "^10.0.0",
     "@types/node": "^10.14.9",
-    "igniteui-angular": "^10.1.0-beta.0",
+    "igniteui-angular": "^10.1.0-rc.0",
     "rxjs": "^6.5.5",
     "tslint": "~6.1.0",
     "typescript": "^3.9.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/forms": "^10.0.0",
     "@angular/platform-browser": "^10.0.0",
     "@types/node": "^10.14.9",
-    "igniteui-angular": "^10.0.0",
+    "igniteui-angular": "^10.1.0-beta.0",
     "rxjs": "^6.5.5",
     "tslint": "~6.1.0",
     "typescript": "^3.9.5",

--- a/src/i18n/ES/carousel-resources.ts
+++ b/src/i18n/ES/carousel-resources.ts
@@ -1,5 +1,11 @@
 import { ICarouselResourceStrings } from 'igniteui-angular';
 
-export const CarouselResourceStringsES: ICarouselResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const CarouselResourceStringsES_: ExpandRequire<ICarouselResourceStrings> = {
     igx_carousel_of: 'of'
 };
+
+/**
+ * Spanish resource strings for IgxCarousel
+ */
+export const CarouselResourceStringsES = CarouselResourceStringsES_ as ExpandRequire<ICarouselResourceStrings>;

--- a/src/i18n/ES/date-range-picker-resources.ts
+++ b/src/i18n/ES/date-range-picker-resources.ts
@@ -1,5 +1,11 @@
 import { IDateRangePickerResourceStrings } from 'igniteui-angular';
 
-export const DateRangePickerResourceStringsES: IDateRangePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const DateRangePickerResourceStringsES_: ExpandRequire<IDateRangePickerResourceStrings> = {
     igx_date_range_picker_date_separator: 'to'
 };
+
+/**
+ * Spanish resource strings for IgxDateRangePicker
+ */
+export const DateRangePickerResourceStringsES = DateRangePickerResourceStringsES_ as ExpandRequire<IDateRangePickerResourceStrings>;

--- a/src/i18n/ES/grid-resources.ts
+++ b/src/i18n/ES/grid-resources.ts
@@ -93,7 +93,7 @@ const GridResourceStringsES_: ExpandRequire<IGridResourceStrings> = {
   igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
   igx_grid_advanced_filter_column_placeholder: 'Select column',
   igx_grid_advanced_filter_value_placeholder: 'Value',
-  igx_grid_pinned_row_indicator: 'TODO'
+  igx_grid_pinned_row_indicator: 'Pinned'
 };
 
 /**

--- a/src/i18n/ES/grid-resources.ts
+++ b/src/i18n/ES/grid-resources.ts
@@ -93,7 +93,12 @@ const GridResourceStringsES_: ExpandRequire<IGridResourceStrings> = {
   igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
   igx_grid_advanced_filter_column_placeholder: 'Select column',
   igx_grid_advanced_filter_value_placeholder: 'Value',
-  igx_grid_pinned_row_indicator: 'Pinned'
+  igx_grid_pinned_row_indicator: 'Pinned',
+  igx_grid_hiding_check_all_label: 'Hide All',
+  igx_grid_hiding_uncheck_all_label: 'Show All',
+  igx_grid_pinning_check_all_label: 'Pin All',
+  igx_grid_pinning_uncheck_all_label: 'Unpin All',
+  igx_grid_toolbar_actions_filter_prompt: 'Filter columns list ...'
 };
 
 /**

--- a/src/i18n/ES/grid-resources.ts
+++ b/src/i18n/ES/grid-resources.ts
@@ -1,9 +1,7 @@
 import { IGridResourceStrings } from 'igniteui-angular';
 
-/**
- * Spanish resource strings for IgxGrid
- */
-export const GridResourceStringsES: IGridResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const GridResourceStringsES_: ExpandRequire<IGridResourceStrings> = {
   igx_grid_groupByArea_message: 'Arrastre un encabezado de columna y suéltelo aquí para agrupar por esa columna.',
   igx_grid_emptyFilteredGrid_message: 'No se encontraron registros.',
   igx_grid_emptyGrid_message: 'No hay datos.',
@@ -94,5 +92,11 @@ export const GridResourceStringsES: IGridResourceStrings = {
   igx_grid_advanced_filter_delete_filters: 'Delete filters',
   igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
   igx_grid_advanced_filter_column_placeholder: 'Select column',
-  igx_grid_advanced_filter_value_placeholder: 'Value'
+  igx_grid_advanced_filter_value_placeholder: 'Value',
+  igx_grid_pinned_row_indicator: 'TODO'
 };
+
+/**
+ * Spanish resource strings for IgxGrid
+ */
+export const GridResourceStringsES = GridResourceStringsES_ as ExpandRequire<IGridResourceStrings>;

--- a/src/i18n/ES/list-resources.ts
+++ b/src/i18n/ES/list-resources.ts
@@ -1,6 +1,13 @@
 import { IListResourceStrings } from 'igniteui-angular';
 
-export const ListResourceStringsES: IListResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const ListResourceStringsES_: ExpandRequire<IListResourceStrings> = {
     igx_list_no_items: 'There are no items in the list.',
     igx_list_loading: 'Loading data from the server...'
 };
+
+/**
+ * Spanish resource strings for IgxList
+ */
+export const ListResourceStringsES = ListResourceStringsES_ as ExpandRequire<IListResourceStrings>;
+

--- a/src/i18n/ES/paginator-resources.ts
+++ b/src/i18n/ES/paginator-resources.ts
@@ -1,9 +1,16 @@
 import { IPaginatorResourceStrings } from 'igniteui-angular';
 
-/**
- * Spanish resource strings for IgxGrid
- */
-export const PaginatorResourceStringsES: IPaginatorResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const PaginatorResourceStringsES_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'Items per page',
-    igx_paginator_pager_text: 'of'
+    igx_paginator_pager_text: 'of',
+    igx_paginator_first_page_button_text: 'TODO',
+    igx_paginator_previous_page_button_text: 'TODO',
+    igx_paginator_last_page_button_text: 'TODO',
+    igx_paginator_next_page_button_text: 'TODO'
 };
+
+/**
+ * Spanish resource strings for IgxPaginator
+ */
+export const PaginatorResourceStringsES = PaginatorResourceStringsES_ as ExpandRequire<IPaginatorResourceStrings>;

--- a/src/i18n/ES/paginator-resources.ts
+++ b/src/i18n/ES/paginator-resources.ts
@@ -4,10 +4,10 @@ import { IPaginatorResourceStrings } from 'igniteui-angular';
 const PaginatorResourceStringsES_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'Items per page',
     igx_paginator_pager_text: 'of',
-    igx_paginator_first_page_button_text: 'TODO',
-    igx_paginator_previous_page_button_text: 'TODO',
-    igx_paginator_last_page_button_text: 'TODO',
-    igx_paginator_next_page_button_text: 'TODO'
+    igx_paginator_first_page_button_text: 'Go to first page',
+    igx_paginator_previous_page_button_text: 'Previous page',
+    igx_paginator_last_page_button_text: 'Go to last page',
+    igx_paginator_next_page_button_text: 'Next page'
 };
 
 /**

--- a/src/i18n/ES/time-picker-resources.ts
+++ b/src/i18n/ES/time-picker-resources.ts
@@ -1,9 +1,12 @@
 import { ITimePickerResourceStrings } from 'igniteui-angular';
 
-/**
- * Spanish resource strings for IgxTimePicker
- */
-export const TimePickerResourceStringsES: ITimePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const TimePickerResourceStringsES_: ExpandRequire<ITimePickerResourceStrings> = {
     igx_time_picker_ok: 'Aceptar',
     igx_time_picker_cancel: 'Cancelar'
 };
+
+/**
+ * Spanish resource strings for IgxTimePicker
+ */
+export const TimePickerResourceStringsES = TimePickerResourceStringsES_ as ExpandRequire<ITimePickerResourceStrings>;

--- a/src/i18n/JA/carousel-resources.ts
+++ b/src/i18n/JA/carousel-resources.ts
@@ -1,7 +1,11 @@
 import { ICarouselResourceStrings } from 'igniteui-angular';
 
-export const CarouselResourceStringsJA = {
+// exported below as re-cast to create declaration type with expanded properties
+const CarouselResourceStringsJA_: ExpandRequire<ICarouselResourceStrings> = {
     igx_carousel_of: '/'
-} as {
-    [Key in keyof ICarouselResourceStrings]: ICarouselResourceStrings[Key]; // Mapped expands when asserted w/ `as`
 };
+
+/**
+ * Japanese resource strings for IgxCarousel
+ */
+export const CarouselResourceStringsJA = CarouselResourceStringsJA_ as ExpandRequire<ICarouselResourceStrings>;

--- a/src/i18n/JA/carousel-resources.ts
+++ b/src/i18n/JA/carousel-resources.ts
@@ -1,5 +1,7 @@
 import { ICarouselResourceStrings } from 'igniteui-angular';
 
-export const CarouselResourceStringsJA: ICarouselResourceStrings = {
+export const CarouselResourceStringsJA = {
     igx_carousel_of: '/'
+} as {
+    [Key in keyof ICarouselResourceStrings]: ICarouselResourceStrings[Key]; // Mapped expands when asserted w/ `as`
 };

--- a/src/i18n/JA/date-range-picker-resources.ts
+++ b/src/i18n/JA/date-range-picker-resources.ts
@@ -1,5 +1,11 @@
 import { IDateRangePickerResourceStrings } from 'igniteui-angular';
 
-export const DateRangePickerResourceStringsJA: IDateRangePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const DateRangePickerResourceStringsJA_: ExpandRequire<IDateRangePickerResourceStrings> = {
     igx_date_range_picker_date_separator: '～'
 };
+
+/**
+ * Japanese resource strings for IgxDateRangePicker
+ */
+export const DateRangePickerResourceStringsJA = DateRangePickerResourceStringsJA_ as ExpandRequire<IDateRangePickerResourceStrings>;

--- a/src/i18n/JA/grid-resources.ts
+++ b/src/i18n/JA/grid-resources.ts
@@ -93,12 +93,12 @@ const GridResourceStringsJA_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_advanced_filter_initial_text: '"And" あるいは "Or" にリンクされた条件のグループの作成から始めます。',
     igx_grid_advanced_filter_column_placeholder: '列の選択',
     igx_grid_advanced_filter_value_placeholder: '値',
-    igx_grid_pinned_row_indicator: '固定',
-    igx_grid_hiding_check_all_label: 'Hide All',
-    igx_grid_hiding_uncheck_all_label: 'Show All',
-    igx_grid_pinning_check_all_label: 'Pin All',
-    igx_grid_pinning_uncheck_all_label: 'Unpin All',
-    igx_grid_toolbar_actions_filter_prompt: 'Filter columns list ...'
+    igx_grid_pinned_row_indicator: '固定済み',
+    igx_grid_hiding_check_all_label: 'すべて非表示',
+    igx_grid_hiding_uncheck_all_label: 'すべて表示',
+    igx_grid_pinning_check_all_label: 'すべて固定',
+    igx_grid_pinning_uncheck_all_label: 'すべて固定解除',
+    igx_grid_toolbar_actions_filter_prompt: '列リストのフィルター'
 };
 
 /**

--- a/src/i18n/JA/grid-resources.ts
+++ b/src/i18n/JA/grid-resources.ts
@@ -93,7 +93,12 @@ const GridResourceStringsJA_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_advanced_filter_initial_text: '"And" あるいは "Or" にリンクされた条件のグループの作成から始めます。',
     igx_grid_advanced_filter_column_placeholder: '列の選択',
     igx_grid_advanced_filter_value_placeholder: '値',
-    igx_grid_pinned_row_indicator: '固定'
+    igx_grid_pinned_row_indicator: '固定',
+    igx_grid_hiding_check_all_label: 'Hide All',
+    igx_grid_hiding_uncheck_all_label: 'Show All',
+    igx_grid_pinning_check_all_label: 'Pin All',
+    igx_grid_pinning_uncheck_all_label: 'Unpin All',
+    igx_grid_toolbar_actions_filter_prompt: 'Filter columns list ...'
 };
 
 /**

--- a/src/i18n/JA/grid-resources.ts
+++ b/src/i18n/JA/grid-resources.ts
@@ -1,9 +1,7 @@
 import { IGridResourceStrings } from 'igniteui-angular';
 
-/**
- * Japanese resource strings for IgxGrid
- */
-export const GridResourceStringsJA: IGridResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const GridResourceStringsJA_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_groupByArea_message: '列ヘッダーをここへドラッグして列をグループ化します。',
     igx_grid_emptyFilteredGrid_message: 'レコードは見つかりませんでした。',
     igx_grid_emptyGrid_message: 'グリッドにデータがありません。',
@@ -94,5 +92,11 @@ export const GridResourceStringsJA: IGridResourceStrings = {
     igx_grid_advanced_filter_delete_filters: 'フィルターの削除',
     igx_grid_advanced_filter_initial_text: '"And" あるいは "Or" にリンクされた条件のグループの作成から始めます。',
     igx_grid_advanced_filter_column_placeholder: '列の選択',
-    igx_grid_advanced_filter_value_placeholder: '値'
+    igx_grid_advanced_filter_value_placeholder: '値',
+    igx_grid_pinned_row_indicator: '固定'
 };
+
+/**
+ * Japanese resource strings for IgxGrid
+ */
+export const GridResourceStringsJA = GridResourceStringsJA_ as ExpandRequire<IGridResourceStrings>;

--- a/src/i18n/JA/list-resources.ts
+++ b/src/i18n/JA/list-resources.ts
@@ -1,6 +1,12 @@
 import { IListResourceStrings } from 'igniteui-angular';
 
-export const ListResourceStringsJA: IListResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const ListResourceStringsJA_: ExpandRequire<IListResourceStrings> = {
     igx_list_no_items: 'リストに項目がありません。',
     igx_list_loading: 'サーバーからデータを読み込んでいます。'
 };
+
+/**
+ * Japanese resource strings for IgxList
+ */
+export const ListResourceStringsJA = ListResourceStringsJA_ as ExpandRequire<IListResourceStrings>;

--- a/src/i18n/JA/paginator-resources.ts
+++ b/src/i18n/JA/paginator-resources.ts
@@ -4,10 +4,10 @@ import { IPaginatorResourceStrings } from 'igniteui-angular';
 const PaginatorResourceStringsJA_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'ページごとの項目',
     igx_paginator_pager_text: '/',
-    igx_paginator_first_page_button_text: 'Go to first page',
-    igx_paginator_previous_page_button_text: 'Previous page',
-    igx_paginator_last_page_button_text: 'Go to last page',
-    igx_paginator_next_page_button_text: 'Next page'
+    igx_paginator_first_page_button_text: '最初のページに移動',
+    igx_paginator_previous_page_button_text: '前のページ',
+    igx_paginator_last_page_button_text: '最後のページに移動',
+    igx_paginator_next_page_button_text: '次のページ'
 };
 
 /**

--- a/src/i18n/JA/paginator-resources.ts
+++ b/src/i18n/JA/paginator-resources.ts
@@ -4,10 +4,10 @@ import { IPaginatorResourceStrings } from 'igniteui-angular';
 const PaginatorResourceStringsJA_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'ページごとの項目',
     igx_paginator_pager_text: '/',
-    igx_paginator_first_page_button_text: 'TODO',
-    igx_paginator_previous_page_button_text: 'TODO',
-    igx_paginator_last_page_button_text: 'TODO',
-    igx_paginator_next_page_button_text: 'TODO'
+    igx_paginator_first_page_button_text: 'Go to first page',
+    igx_paginator_previous_page_button_text: 'Previous page',
+    igx_paginator_last_page_button_text: 'Go to last page',
+    igx_paginator_next_page_button_text: 'Next page'
 };
 
 /**

--- a/src/i18n/JA/paginator-resources.ts
+++ b/src/i18n/JA/paginator-resources.ts
@@ -1,9 +1,16 @@
 import { IPaginatorResourceStrings } from 'igniteui-angular';
 
-/**
- * Spanish resource strings for IgxGrid
- */
-export const PaginatorResourceStringsJA: IPaginatorResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const PaginatorResourceStringsJA_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'ページごとの項目',
-    igx_paginator_pager_text: '/'
+    igx_paginator_pager_text: '/',
+    igx_paginator_first_page_button_text: 'TODO',
+    igx_paginator_previous_page_button_text: 'TODO',
+    igx_paginator_last_page_button_text: 'TODO',
+    igx_paginator_next_page_button_text: 'TODO'
 };
+
+/**
+ * Japanese resource strings for IgxPaginator
+ */
+export const PaginatorResourceStringsJA = PaginatorResourceStringsJA_ as ExpandRequire<IPaginatorResourceStrings>;

--- a/src/i18n/JA/time-picker-resources.ts
+++ b/src/i18n/JA/time-picker-resources.ts
@@ -1,9 +1,13 @@
 import { ITimePickerResourceStrings } from 'igniteui-angular';
 
-/**
- * Japanese resource strings for IgxTimePicker
- */
-export const TimePickerResourceStringsJA: ITimePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const TimePickerResourceStringsJA_: ExpandRequire<ITimePickerResourceStrings> = {
     igx_time_picker_ok: 'OK',
     igx_time_picker_cancel: 'キャンセル'
 };
+
+
+/**
+ * Japanese resource strings for IgxTimePicker
+ */
+export const TimePickerResourceStringsJA = TimePickerResourceStringsJA_ as ExpandRequire<ITimePickerResourceStrings>;

--- a/src/i18n/KO/carousel-resources.ts
+++ b/src/i18n/KO/carousel-resources.ts
@@ -1,5 +1,11 @@
 import { ICarouselResourceStrings } from 'igniteui-angular';
 
-export const CarouselResourceStringsKO: ICarouselResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const CarouselResourceStringsKO_: ExpandRequire<ICarouselResourceStrings> = {
     igx_carousel_of: 'of'
 };
+
+/**
+ * Korean resource strings for IgxCarousel
+ */
+export const CarouselResourceStringsKO = CarouselResourceStringsKO_ as ExpandRequire<ICarouselResourceStrings>;

--- a/src/i18n/KO/date-range-picker-resources.ts
+++ b/src/i18n/KO/date-range-picker-resources.ts
@@ -1,5 +1,11 @@
 import { IDateRangePickerResourceStrings } from 'igniteui-angular';
 
-export const DateRangePickerResourceStringsKO: IDateRangePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const DateRangePickerResourceStringsKO_: ExpandRequire<IDateRangePickerResourceStrings> = {
     igx_date_range_picker_date_separator: 'to'
 };
+
+/**
+ * Korean resource strings for IgxDateRangePicker
+ */
+export const DateRangePickerResourceStringsKO = DateRangePickerResourceStringsKO_ as ExpandRequire<IDateRangePickerResourceStrings>;

--- a/src/i18n/KO/grid-resources.ts
+++ b/src/i18n/KO/grid-resources.ts
@@ -93,7 +93,7 @@ const GridResourceStringsKO_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
     igx_grid_advanced_filter_column_placeholder: 'Select column',
     igx_grid_advanced_filter_value_placeholder: 'Value',
-    igx_grid_pinned_row_indicator: 'TODO'
+    igx_grid_pinned_row_indicator: 'Pinned'
 };
 
 

--- a/src/i18n/KO/grid-resources.ts
+++ b/src/i18n/KO/grid-resources.ts
@@ -1,9 +1,7 @@
 import { IGridResourceStrings } from 'igniteui-angular';
 
-/**
- * Korean resource strings for IgxGrid
- */
-export const GridResourceStringsKO: IGridResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const GridResourceStringsKO_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_groupByArea_message: 'Drag a column header and drop it here to group by that column.',
     igx_grid_emptyFilteredGrid_message: 'No records found.',
     igx_grid_emptyGrid_message: 'Grid has no data.',
@@ -94,5 +92,12 @@ export const GridResourceStringsKO: IGridResourceStrings = {
     igx_grid_advanced_filter_delete_filters: 'Delete filters',
     igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
     igx_grid_advanced_filter_column_placeholder: 'Select column',
-    igx_grid_advanced_filter_value_placeholder: 'Value'
+    igx_grid_advanced_filter_value_placeholder: 'Value',
+    igx_grid_pinned_row_indicator: 'TODO'
 };
+
+
+/**
+ * Korean resource strings for IgxGrid
+ */
+export const GridResourceStringsKO = GridResourceStringsKO_ as ExpandRequire<IGridResourceStrings>;

--- a/src/i18n/KO/grid-resources.ts
+++ b/src/i18n/KO/grid-resources.ts
@@ -93,7 +93,12 @@ const GridResourceStringsKO_: ExpandRequire<IGridResourceStrings> = {
     igx_grid_advanced_filter_initial_text: 'Start with creating a group of conditions linked with "And" or "Or"',
     igx_grid_advanced_filter_column_placeholder: 'Select column',
     igx_grid_advanced_filter_value_placeholder: 'Value',
-    igx_grid_pinned_row_indicator: 'Pinned'
+    igx_grid_pinned_row_indicator: 'Pinned',
+    igx_grid_hiding_check_all_label: 'Hide All',
+    igx_grid_hiding_uncheck_all_label: 'Show All',
+    igx_grid_pinning_check_all_label: 'Pin All',
+    igx_grid_pinning_uncheck_all_label: 'Unpin All',
+    igx_grid_toolbar_actions_filter_prompt: 'Filter columns list ...'
 };
 
 

--- a/src/i18n/KO/list-resources.ts
+++ b/src/i18n/KO/list-resources.ts
@@ -1,6 +1,12 @@
 import { IListResourceStrings } from 'igniteui-angular';
 
-export const ListResourceStringsKO: IListResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const ListResourceStringsKO_: ExpandRequire<IListResourceStrings> = {
     igx_list_no_items: 'There are no items in the list.',
     igx_list_loading: 'Loading data from the server...'
 };
+
+/**
+ * Korean resource strings for IgxList
+ */
+export const ListResourceStringsKO = ListResourceStringsKO_ as ExpandRequire<IListResourceStrings>;

--- a/src/i18n/KO/paginator-resources.ts
+++ b/src/i18n/KO/paginator-resources.ts
@@ -1,9 +1,16 @@
 import { IPaginatorResourceStrings } from 'igniteui-angular';
 
-/**
- * Spanish resource strings for IgxGrid
- */
-export const PaginatorResourceStringsKO: IPaginatorResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const PaginatorResourceStringsKO_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'Items per page',
-    igx_paginator_pager_text: 'of'
+    igx_paginator_pager_text: 'of',
+    igx_paginator_first_page_button_text: 'TODO',
+    igx_paginator_previous_page_button_text: 'TODO',
+    igx_paginator_last_page_button_text: 'TODO',
+    igx_paginator_next_page_button_text: 'TODO'
 };
+
+/**
+ * Korean resource strings for IgxPaginator
+ */
+export const PaginatorResourceStringsKO = PaginatorResourceStringsKO_ as ExpandRequire<IPaginatorResourceStrings>;

--- a/src/i18n/KO/paginator-resources.ts
+++ b/src/i18n/KO/paginator-resources.ts
@@ -4,10 +4,10 @@ import { IPaginatorResourceStrings } from 'igniteui-angular';
 const PaginatorResourceStringsKO_: ExpandRequire<IPaginatorResourceStrings> = {
     igx_paginator_label: 'Items per page',
     igx_paginator_pager_text: 'of',
-    igx_paginator_first_page_button_text: 'TODO',
-    igx_paginator_previous_page_button_text: 'TODO',
-    igx_paginator_last_page_button_text: 'TODO',
-    igx_paginator_next_page_button_text: 'TODO'
+    igx_paginator_first_page_button_text: 'Go to first page',
+    igx_paginator_previous_page_button_text: 'Previous page',
+    igx_paginator_last_page_button_text: 'Go to last page',
+    igx_paginator_next_page_button_text: 'Next page'
 };
 
 /**

--- a/src/i18n/KO/time-picker-resources.ts
+++ b/src/i18n/KO/time-picker-resources.ts
@@ -1,9 +1,13 @@
 import { ITimePickerResourceStrings } from 'igniteui-angular';
 
-/**
- * Korean resource strings for IgxTimePicker
- */
-export const TimePickerResourceStringsKO: ITimePickerResourceStrings = {
+// exported below as re-cast to create declaration type with expanded properties
+const TimePickerResourceStringsKO_: ExpandRequire<ITimePickerResourceStrings> = {
     igx_time_picker_ok: 'OK',
     igx_time_picker_cancel: 'Cancel'
 };
+
+
+/**
+ * Korean resource strings for IgxTimePicker
+ */
+export const TimePickerResourceStringsKO = TimePickerResourceStringsKO_ as ExpandRequire<ITimePickerResourceStrings>;

--- a/src/i18n/expand-type.ts
+++ b/src/i18n/expand-type.ts
@@ -1,0 +1,6 @@
+/**
+ * @internal
+ * Expands object types (one level) and makes properties required
+ * https://stackoverflow.com/a/57683652
+ */
+type ExpandRequire<T> = T extends infer O ? { [K in keyof O]-?: O[K] } : never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
       "target": "es2015",
       "module": "commonjs",
       "declaration": true,
-      "outDir": "./dist"
+      "outDir": "./dist",
+      "stripInternal": true
     }
 }

--- a/tslint.dist.json
+++ b/tslint.dist.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tslint.json",
+  "rules": {
+    "import-blacklist": [true, "igniteui-angular"]
+  }
+}


### PR DESCRIPTION
Closes #37
Basic idea: Make the exported resource strings type their own object schema. That should match the resource interfaces in Ignite UI for Angular by schema alone and wouldn't matter which package version is used.

- Type assert exports as expanded resource interfaces (removing import dependency on prod package)
- Output type expanded to object schema only seems to work with type assert (`as T`), however that also negates all checks for props
- So resources are first annotated (with the optional flag removed from all pros) so compilation will fail for missing ones (hint: already did find one) and then exported with type assert to produce something like this:

```ts
// grid-resources.d.ts:
/**
 * Japanese resource strings for IgxGrid
 */
export declare const GridResourceStringsJA: {
    igx_grid_groupByArea_message: string;
    igx_grid_emptyFilteredGrid_message: string;
    igx_grid_emptyGrid_message: string;
    igx_grid_filter: string;
    //...
}
```